### PR TITLE
Add structured logging and request correlation middleware

### DIFF
--- a/app/logging_conf.py
+++ b/app/logging_conf.py
@@ -1,0 +1,112 @@
+"""Application-level structured logging configuration utilities."""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import sys
+from datetime import datetime
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from app.config import settings
+
+_ctx_request_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "request_id", default=None
+)
+_ctx_job_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "job_id", default=None
+)
+_ctx_run_number: contextvars.ContextVar[int | None] = contextvars.ContextVar(
+    "run_number", default=None
+)
+
+
+_ZONE = ZoneInfo(settings.tz)
+
+
+class _JsonLogFormatter(logging.Formatter):
+    """Serialize log records into single-line JSON objects."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_context = get_log_context()
+        timestamp = datetime.now(_ZONE).isoformat(
+            timespec="milliseconds"
+        )
+
+        message: str
+        try:
+            message = record.getMessage()
+        except Exception:  # pragma: no cover - defensive
+            message = str(record.msg)
+
+        payload: dict[str, Any] = {
+            "ts": timestamp,
+            "level": record.levelname,
+            "logger": record.name,
+            "module": record.module,
+            "func": record.funcName,
+            "line": record.lineno,
+            "message": message,
+            "request_id": log_context.get("request_id"),
+            "job_id": log_context.get("job_id"),
+            "run_number": log_context.get("run_number"),
+        }
+
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+
+        return json.dumps(payload, ensure_ascii=False)
+
+
+_configured = False
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Configure the root logger to emit JSON logs with shared context."""
+
+    global _configured
+    if _configured:
+        logging.getLogger().setLevel(level)
+        return
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+    root_logger.handlers.clear()
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(level)
+    handler.setFormatter(_JsonLogFormatter())
+    root_logger.addHandler(handler)
+
+    for name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+        uvicorn_logger = logging.getLogger(name)
+        uvicorn_logger.handlers.clear()
+        uvicorn_logger.setLevel(level)
+        uvicorn_logger.propagate = True
+
+    _configured = True
+
+
+def set_request_id(value: str | None) -> None:
+    """Set the current request identifier in the logging context."""
+
+    _ctx_request_id.set(value)
+
+
+def set_job_context(job_id: str | None, run_number: int | None) -> None:
+    """Set the job correlation identifiers in the logging context."""
+
+    _ctx_job_id.set(job_id)
+    _ctx_run_number.set(run_number)
+
+
+def get_log_context() -> dict[str, Any]:
+    """Return a shallow copy of the current logging context values."""
+
+    return {
+        "request_id": _ctx_request_id.get(),
+        "job_id": _ctx_job_id.get(),
+        "run_number": _ctx_run_number.get(),
+    }

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,0 +1,38 @@
+"""Custom FastAPI middleware for logging context propagation."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+from starlette.types import RequestResponseEndpoint
+
+from app import logging_conf
+
+
+class RequestContextMiddleware(BaseHTTPMiddleware):
+    """Attach and propagate a request identifier for each HTTP request."""
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        incoming_request_id = (request.headers.get("X-Request-ID") or "").strip()
+        request_id = incoming_request_id or uuid.uuid4().hex
+        logging_conf.set_request_id(request_id)
+
+        try:
+            response = await call_next(request)
+        finally:
+            logging_conf.set_request_id(None)
+            logging_conf.set_job_context(None, None)
+
+        response.headers["X-Request-ID"] = request_id
+        return response
+
+
+def get_request_id_from_context() -> str | None:
+    """Retrieve the current request identifier from the logging context."""
+
+    return logging_conf.get_log_context().get("request_id")

--- a/app/queue.py
+++ b/app/queue.py
@@ -6,6 +6,8 @@ import asyncio
 import logging
 import uuid
 
+from app import logging_conf
+
 
 logger = logging.getLogger(__name__)
 
@@ -17,9 +19,13 @@ def enqueue_run_now() -> str:
 
     job_id = str(uuid.uuid4())
     try:
+        logging_conf.set_job_context(job_id, None)
         _queue.put_nowait(job_id)
+        logger.info("job enqueued (stub)")
     except asyncio.QueueFull:
         logger.warning("Queue is full; job %s could not be enqueued", job_id)
+    finally:
+        logging_conf.set_job_context(None, None)
     return job_id
 
 


### PR DESCRIPTION
## Summary
- configure JSON-based root logging with context variables for requests and jobs
- add middleware to manage X-Request-ID headers and propagate logging context
- update API endpoints and queue stub to emit structured logs with correlation metadata

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d8e9fb3fc8832e8b2b1004fb86a7d0