### PR TITLE
Add assistant-based prompt generation service

### DIFF
--- a/app/services/assistant_service.py
+++ b/app/services/assistant_service.py
@@ -1,0 +1,140 @@
+"""Integration with the OpenAI Assistants API for prompt generation."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from typing import Optional
+
+from openai import OpenAI
+from openai.types.beta.threads import Run
+
+from app.config import settings
+from app.logging_conf import get_log_context
+from app.services import prompt_templates
+from app.services.prompt_guard import sanitize, validate_prompt
+
+LOGGER = logging.getLogger(__name__)
+CLIENT = OpenAI(api_key=settings.openai_api_key)
+MODEL = "gpt-4o-mini"
+POLL_INTERVAL_SECONDS = 0.5
+POLL_TIMEOUT_SECONDS = 90.0
+
+
+def _sha1(text: str) -> str:
+    """Return the first 12 hexadecimal characters of a SHA1 digest."""
+
+    digest = hashlib.sha1(text.encode("utf-8"))
+    return digest.hexdigest()[:12]
+
+
+def _poll_run(thread_id: str, run_id: str) -> Run:
+    """Poll the run until it reaches a terminal state."""
+
+    deadline = time.monotonic() + POLL_TIMEOUT_SECONDS
+    while True:
+        run = CLIENT.beta.threads.runs.retrieve(thread_id=thread_id, run_id=run_id)
+        if run.status in {"completed", "failed", "cancelled", "expired"}:
+            return run
+        if time.monotonic() > deadline:
+            raise RuntimeError("assistant_run_timeout")
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+def _extract_latest_text(thread_id: str) -> str:
+    """Fetch the latest assistant message text from the thread."""
+
+    messages = CLIENT.beta.threads.messages.list(thread_id=thread_id, order="desc", limit=5)
+    for message in messages.data:
+        if message.role != "assistant":
+            continue
+        text_fragments: list[str] = []
+        for content in message.content:
+            if content.type == "text" and content.text:
+                text_fragments.append(content.text.value)
+        if text_fragments:
+            return "\n".join(text_fragments)
+    raise RuntimeError("assistant_no_text_response")
+
+
+def _create_assistant() -> str:
+    assistant = CLIENT.beta.assistants.create(
+        model=MODEL,
+        instructions=prompt_templates.ASSISTANT_SYSTEM,
+        name="Leatherwear Prompt Assistant",
+    )
+    return assistant.id
+
+
+def generate_prompt_text() -> str:
+    """Generate a single sanitized, validated prompt string via the Assistants API."""
+
+    logged_error = False
+    last_error: Optional[str] = None
+    try:
+        for attempt in range(2):
+            user_prompt = prompt_templates.build_randomized_user_prompt()
+            assistant_id = _create_assistant()
+            thread = CLIENT.beta.threads.create()
+            CLIENT.beta.threads.messages.create(
+                thread_id=thread.id,
+                role="user",
+                content=user_prompt,
+            )
+            run = CLIENT.beta.threads.runs.create(
+                thread_id=thread.id,
+                assistant_id=assistant_id,
+            )
+            run = _poll_run(thread.id, run.id)
+            if run.status != "completed":
+                error_message = getattr(run, "last_error", None)
+                reason = error_message.get("message") if isinstance(error_message, dict) else run.status
+                LOGGER.error(
+                    "assistant prompt generation failed",
+                    extra={"reason": reason, "attempt": attempt + 1},
+                )
+                logged_error = True
+                raise RuntimeError(f"assistant_run_{run.status}")
+
+            raw_text = _extract_latest_text(thread.id)
+            sanitized = sanitize(raw_text)
+            is_valid, reason = validate_prompt(sanitized)
+            if is_valid:
+                context = get_log_context()
+                LOGGER.info(
+                    "assistant prompt generated",
+                    extra={
+                        "len": len(sanitized),
+                        "sha1": _sha1(sanitized),
+                        "request_id": context.get("request_id"),
+                    },
+                )
+                return sanitized
+
+            last_error = reason
+            LOGGER.warning(
+                "assistant prompt validation failed",
+                extra={"reason": reason, "attempt": attempt + 1},
+            )
+
+        LOGGER.error(
+            "assistant prompt generation failed",
+            extra={"reason": last_error or "validation_failed"},
+        )
+        logged_error = True
+        raise RuntimeError("prompt_validation_failed")
+    except Exception as exc:  # noqa: BLE001
+        if not logged_error:
+            LOGGER.error(
+                "assistant prompt generation failed",
+                extra={"reason": f"{exc.__class__.__name__}:{exc}"},
+            )
+        raise
+
+
+"""Example usage (manual testing only):
+>>> from app.services.assistant_service import generate_prompt_text
+>>> prompt = generate_prompt_text()
+>>> print(len(prompt), prompt[:140])
+"""

--- a/app/services/prompt_guard.py
+++ b/app/services/prompt_guard.py
@@ -1,0 +1,86 @@
+"""Basic sanitization and validation for generated prompts."""
+
+from __future__ import annotations
+
+import re
+from typing import Tuple
+
+FORBIDDEN_KEYWORDS = {
+    "nude",
+    "nudity",
+    "lingerie",
+    "bikini",
+    "underwear",
+    "see-through",
+    "transparent",
+    "sheer",
+    "explicit",
+    "erotic",
+    "fetish",
+    "latex catsuit",
+    "latex bodysuit",
+    "lolita",
+    "schoolgirl",
+    "teen",
+    "underage",
+    "minor",
+    "gucci",
+    "prada",
+    "chanel",
+    "versace",
+    "balenciaga",
+    "dior",
+    "fendi",
+    "ysl",
+    "saint laurent",
+    "louis vuitton",
+    "lv",
+    "hermes",
+    "burberry",
+    "celine",
+    "armani",
+    "valentino",
+    "givenchy",
+    "coach",
+    "bottega",
+    "miu miu",
+    "dolce",
+    "gabbana",
+}
+
+REQUIRED_KEYWORDS = {"leather", "vertical"}
+
+MIN_LENGTH = 200
+MAX_LENGTH = 900
+
+
+def sanitize(text: str) -> str:
+    """Return a single-line sanitized string without markdown fences."""
+
+    cleaned = text.replace("```", "")
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    return cleaned.strip()
+
+
+def validate_prompt(text: str) -> Tuple[bool, str]:
+    """Validate prompt length and keyword presence."""
+
+    sanitized = sanitize(text)
+    if not sanitized:
+        return False, "empty_prompt"
+
+    normalized = sanitized.lower()
+    for forbidden in FORBIDDEN_KEYWORDS:
+        if forbidden in normalized:
+            return False, f"forbidden_keyword:{forbidden}"
+
+    for required in REQUIRED_KEYWORDS:
+        if required not in normalized:
+            return False, f"missing_required:{required}"
+
+    if len(sanitized) < MIN_LENGTH:
+        return False, "prompt_too_short"
+    if len(sanitized) > MAX_LENGTH:
+        return False, "prompt_too_long"
+
+    return True, ""

--- a/app/services/prompt_templates.py
+++ b/app/services/prompt_templates.py
@@ -1,0 +1,240 @@
+"""Prompt templates and randomization utilities for the leatherwear assistant."""
+
+from __future__ import annotations
+
+import random
+from typing import Iterable, Sequence
+
+ASSISTANT_SYSTEM = """
+You are a fashion prompt generator specialized in SFW women’s leatherwear. Produce exactly one polished text-to-image prompt per request. Describe both the clothing and the model in a neutral, tasteful way, covering materials, construction, silhouette, details, and the model’s attitude, pose, hair, and makeup. Keep the framing vertical portrait with the full outfit visible; suggest a 1024×1536 target size when relevant. Avoid brand names and copyrighted characters. Stay SFW with no nudity and no minors. Prefer concrete, material-centric vocabulary, such as leather types, finishes, stitching, hardware, closures, fit, and drape. Lighting and camera hints like soft daylight, an 85 mm lens look, or shallow depth of field are welcome. Output only the final prompt text with no preamble or markdown.
+""".strip()
+
+SILHOUETTES: Sequence[str] = (
+    "tailored leather suit with sharp shoulders",
+    "structured trench coat with cinched waist",
+    "sleek bodycon midi dress",
+    "A-line leather mini dress",
+    "fitted sheath dress with paneled leather",
+    "biker jacket paired with high-waist mini skirt",
+    "corset top layered over high-waist pencil skirt",
+    "streamlined leather jumpsuit",
+    "peplum jacket with tapered trousers",
+    "sculpted moto jacket over column skirt",
+)
+
+GARMENTS: Sequence[str] = (
+    "double-breasted trench coat",
+    "tailored blazer",
+    "structured corset",
+    "panelled bodycon dress",
+    "wrap dress",
+    "high-waist pencil skirt",
+    "tapered trousers",
+    "mini skirt",
+    "moto jacket",
+    "fitted sheath dress",
+)
+
+LEATHER_TYPES: Sequence[str] = (
+    "full-grain leather with a soft matte finish",
+    "buttery aniline leather",
+    "semi-aniline leather with gentle sheen",
+    "patent leather with mirror gloss",
+    "high-gloss lacquered leather",
+    "pebble-grain leather",
+    "nubuck leather",
+    "velvety suede leather",
+    "embossed crocodile leather",
+    "embossed snakeskin leather",
+)
+
+COLORS: Sequence[str] = (
+    "deep black",
+    "oxblood red",
+    "cognac brown",
+    "forest green",
+    "midnight blue",
+    "ivory",
+    "steel grey",
+    "charcoal",
+    "deep burgundy",
+    "ink navy",
+)
+
+DETAILING: Sequence[str] = (
+    "hand-stitched seams",
+    "tonal topstitching",
+    "corsetry boning channels",
+    "lace-up side panels",
+    "quilted shoulder panels",
+    "articulated sleeves",
+    "asymmetric front zip",
+    "polished rivet hardware",
+    "matte snap buttons",
+    "belt with statement buckle",
+)
+
+ACCESSORIES: Sequence[str] = (
+    "structured mini bag",
+    "sleek leather gloves",
+    "minimal choker",
+    "thin waist belt",
+    "polished metallic cuff",
+    "delicate drop earrings",
+)
+
+FOOTWEAR: Sequence[str] = (
+    "ankle boots",
+    "knee-high boots",
+    "over-the-knee boots",
+    "heeled sandals with leather straps",
+    "block-heel boots",
+)
+
+MODEL_DESCRIPTORS: Sequence[str] = (
+    "poised expression",
+    "confident stance",
+    "calm gaze",
+    "sleek low ponytail",
+    "soft waves",
+    "chin-length bob",
+    "natural glow makeup",
+    "classic eyeliner",
+    "soft matte lips",
+    "defined cheekbones",
+)
+
+POSES: Sequence[str] = (
+    "three-quarter stance",
+    "contrapposto pose",
+    "walking stride",
+    "seated edge pose with straight posture",
+    "mid-step turn",
+)
+
+SCENES: Sequence[str] = (
+    "studio seamless backdrop",
+    "concrete loft interior",
+    "minimal set with textured wall",
+    "moody runway reflection",
+    "modern city rooftop",
+    "architectural atrium",
+)
+
+LIGHTING: Sequence[str] = (
+    "soft daylight glow",
+    "moody chiaroscuro lighting",
+    "rim light accent",
+    "diffused key light",
+    "golden-hour backlight",
+)
+
+CAMERA: Sequence[str] = (
+    "vertical portrait framing",
+    "85 mm lens look",
+    "shallow depth of field",
+    "subtle film grain",
+    "fine-grain medium format look",
+)
+
+MOODS: Sequence[str] = (
+    "elevated mood",
+    "modern and refined",
+    "bold yet composed",
+    "sculptural elegance",
+    "minimalist confidence",
+)
+
+
+def _sample(items: Sequence[str], *, k: int) -> list[str]:
+    if k <= 0:
+        return []
+    k = min(k, len(items))
+    return random.sample(list(items), k=k)
+
+
+def _choose(items: Sequence[str]) -> str:
+    return random.choice(list(items))
+
+
+def _select_lighting(leather: str) -> str:
+    dramatic_keywords = ("patent", "high-gloss", "mirror gloss", "lacquered")
+    if any(keyword in leather for keyword in dramatic_keywords):
+        dramatic_lighting = [
+            option
+            for option in LIGHTING
+            if "chiaroscuro" in option or "rim light" in option or "backlight" in option
+        ]
+        if dramatic_lighting:
+            return random.choice(dramatic_lighting)
+    return _choose(LIGHTING)
+
+
+def _select_scene(leather: str) -> str:
+    dramatic_keywords = ("patent", "high-gloss", "mirror gloss", "lacquered")
+    if any(keyword in leather for keyword in dramatic_keywords):
+        reflective_scenes = [
+            option for option in SCENES if "runway" in option or "rooftop" in option
+        ]
+        if reflective_scenes:
+            return random.choice(reflective_scenes)
+    return _choose(SCENES)
+
+
+def _build_layering_note(garments: Iterable[str]) -> str:
+    for garment in garments:
+        if "corset" in garment.lower():
+            return (
+                "Layer the corset over a fitted base or under a structured blazer to maintain a tasteful, SFW presentation."
+            )
+    return ""
+
+
+def build_randomized_user_prompt() -> str:
+    silhouette = _choose(SILHOUETTES)
+    garment_count = 1 if random.random() < 0.5 else 2
+    garments = _sample(GARMENTS, k=garment_count)
+    leather = _choose(LEATHER_TYPES)
+    color = _choose(COLORS)
+    detailing = _sample(DETAILING, k=2)
+    accessories = _sample(ACCESSORIES, k=1)
+    footwear = _choose(FOOTWEAR)
+    model_descriptors = _sample(MODEL_DESCRIPTORS, k=2)
+    pose = _choose(POSES)
+    scene = _select_scene(leather)
+    lighting = _select_lighting(leather)
+    camera = _sample(CAMERA, k=2)
+    mood = _choose(MOODS)
+
+    layering_note = _build_layering_note(garments)
+
+    if "trench" in silhouette or any("trench" in garment.lower() for garment in garments):
+        mood = "modern and refined"
+
+    prompt_parts = [
+        "Generate exactly one SFW text-to-image prompt in English for a women's leather outfit.",
+        f"Silhouette focus: {silhouette}.",
+        f"Primary garments: {', '.join(garments)}.",
+        f"Leather material emphasis: {leather} in {color}.",
+        f"Detailing cues: {', '.join(detailing)}.",
+        f"Accessories: {', '.join(accessories)}." if accessories else "",
+        f"Footwear: {footwear}.",
+        f"Model styling notes: {', '.join(model_descriptors)}.",
+        f"Pose direction: {pose}.",
+        f"Scene inspiration: {scene}.",
+        f"Lighting direction: {lighting}.",
+        f"Camera and framing: {', '.join(camera)}.",
+        f"Overall mood: {mood}.",
+        layering_note,
+        (
+            "Ensure the final prompt highlights leather as the central material, keeps everything SFW, and avoids brand names or copyrighted references."
+        ),
+        (
+            "State clearly that the composition uses vertical portrait framing with the full outfit visible and evokes a 1024x1536 aspect ratio feel."
+        ),
+        "Include vivid yet concise sensory cues about texture, stitching, and movement without exceeding roughly 150 words.",
+        "Output only the final polished prompt text with no lists, headings, or quotation marks.",
+    ]
+
+    filtered_parts = [part for part in prompt_parts if part]
+    return " ".join(filtered_parts)


### PR DESCRIPTION
## Summary
- add women’s leatherwear system prompt and randomized seed builder for the assistant
- provide sanitization and validation utilities to enforce sfw, leather-focused outputs
- integrate the OpenAI Assistants API to produce prompts with retries and structured logging

## Testing
- python -m compileall app/services/prompt_templates.py app/services/prompt_guard.py app/services/assistant_service.py

------
https://chatgpt.com/codex/tasks/task_e_68d8f5b3b6dc832e88f251b89f6471ab