### PR TITLE
Fix Gemini image generation fallback and logging extras

### DIFF
--- a/app/smoke_test.py
+++ b/app/smoke_test.py
@@ -71,7 +71,7 @@ def main() -> None:
     except Exception as exc:  # noqa: BLE001
         LOGGER.error(
             "smoke test failed",
-            extra={"error": exc.__class__.__name__, "message": str(exc)},
+            extra={"err": exc.__class__.__name__, "detail": str(exc)},
         )
         sys.exit(1)
 


### PR DESCRIPTION
## Summary
- remove unsupported `image_size` usage, append framing hints to prompts, and retry Gemini image generation safely
- harden PNG extraction and logging metadata while respecting SDK feature detection
- update smoke test logging extras to avoid reserved keys

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d8fc908f00832eb584795f11f9bd24