### PR TITLE
Fix Gemini image generation handling

### DIFF
--- a/app/smoke_test.py
+++ b/app/smoke_test.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
-import sys
 from typing import Sequence
 
 from app import logging_conf
@@ -62,18 +61,15 @@ def main() -> None:
 
         if args.no_send:
             _print_diagnostics(images)
-            LOGGER.info("smoke success", extra={"count": len(images), "sent": False})
+            LOGGER.info("smoke success: count=%d sent=%s", len(images), False)
             return
 
         caption = _format_caption(prompt, len(images), aspect_key)
         asyncio.run(telegram_service.send_images_with_caption(list(images), caption))
-        LOGGER.info("smoke success", extra={"count": len(images), "sent": True})
+        LOGGER.info("smoke success: count=%d sent=%s", len(images), True)
     except Exception as exc:  # noqa: BLE001
-        LOGGER.error(
-            "smoke test failed",
-            extra={"err": exc.__class__.__name__, "detail": str(exc)},
-        )
-        sys.exit(1)
+        LOGGER.error("smoke test failed: %s: %s", exc.__class__.__name__, str(exc))
+        raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update the Gemini service to prefer the Images API, fall back to the generative model, and harden PNG extraction and logging
- append the prompt framing hint based on aspect presets while ensuring retries top up missing images
- adjust the smoke test logging to include exception details directly in the log messages

## Testing
- python -m compileall app/services/gemini_service.py app/smoke_test.py

------
https://chatgpt.com/codex/tasks/task_e_68d8ffa314f4832eb4621a876a0d8bf1