### PR TITLE
Send Telegram albums without caption and forward prompts as text

### DIFF
--- a/app/smoke_test.py
+++ b/app/smoke_test.py
@@ -32,16 +32,12 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _format_caption(prompt: str, count: int, aspect: str) -> str:
-    trimmed_prompt = prompt if len(prompt) <= 3000 else f"{prompt[:2997]}..."
-    lines = [
-        "Nano Banana — smoke",
-        f"Model: {gemini_service.MODEL_NAME}",
-        f"Count: {count}, Aspect: {aspect}",
-        "",
-        trimmed_prompt,
-    ]
-    return "\n".join(lines)
+def _format_header(count: int, aspect: str) -> str:
+    return (
+        "Nano Banana — smoke | "
+        f"{gemini_service.MODEL_NAME} | "
+        f"count={count} | aspect={aspect} | format=png"
+    )
 
 
 def _print_diagnostics(images: Sequence[bytes]) -> None:
@@ -64,8 +60,12 @@ def main() -> None:
             LOGGER.info("smoke success: count=%d sent=%s", len(images), False)
             return
 
-        caption = _format_caption(prompt, len(images), aspect_key)
-        asyncio.run(telegram_service.send_images_with_caption(list(images), caption))
+        header = _format_header(len(images), aspect_key)
+        asyncio.run(
+            telegram_service.send_images_and_prompt(
+                list(images), prompt_text=prompt, header=header
+            )
+        )
         LOGGER.info("smoke success: count=%d sent=%s", len(images), True)
     except Exception as exc:  # noqa: BLE001
         LOGGER.error("smoke test failed: %s: %s", exc.__class__.__name__, str(exc))


### PR DESCRIPTION
## Summary
- add text chunking and target resolution helpers to the Telegram service and implement a new `send_images_and_prompt` flow that sends albums without captions followed by chunked prompt messages
- keep `send_images_with_caption` for compatibility by delegating to the new implementation and add flood-wait retry handling for uploads and message sends
- update the smoke test to pass a concise header and the full prompt text to the Telegram service

## Testing
- python -m compileall app/services/telegram_service.py app/smoke_test.py

------
https://chatgpt.com/codex/tasks/task_e_68d9032df8cc832eb5a9784beff6b635