### PR TITLE
Refactor Gemini prompt flow to relax guards and add pre-generation delay

### DIFF
--- a/app/services/prompt_guard.py
+++ b/app/services/prompt_guard.py
@@ -1,4 +1,4 @@
-"""Basic sanitization and validation for generated prompts."""
+"""Basic sanitization and soft validation for generated prompts."""
 
 from __future__ import annotations
 
@@ -12,46 +12,19 @@ FORBIDDEN_KEYWORDS = {
     "bikini",
     "underwear",
     "see-through",
-    "transparent",
-    "sheer",
     "explicit",
     "erotic",
     "fetish",
-    "latex catsuit",
-    "latex bodysuit",
+    "sexual",
     "lolita",
     "schoolgirl",
     "teen",
     "underage",
     "minor",
-    "gucci",
-    "prada",
-    "chanel",
-    "versace",
-    "balenciaga",
-    "dior",
-    "fendi",
-    "ysl",
-    "saint laurent",
-    "louis vuitton",
-    "lv",
-    "hermes",
-    "burberry",
-    "celine",
-    "armani",
-    "valentino",
-    "givenchy",
-    "coach",
-    "bottega",
-    "miu miu",
-    "dolce",
-    "gabbana",
 }
 
-REQUIRED_KEYWORDS = {"leather", "vertical"}
-
-MIN_LENGTH = 200
-MAX_LENGTH = 900
+_SHORT_HINT_THRESHOLD = 60
+_LONG_HINT_THRESHOLD = 1200
 
 
 def sanitize(text: str) -> str:
@@ -63,7 +36,7 @@ def sanitize(text: str) -> str:
 
 
 def validate_prompt(text: str) -> Tuple[bool, str]:
-    """Validate prompt length and keyword presence."""
+    """Sanitize and softly validate the generated prompt."""
 
     sanitized = sanitize(text)
     if not sanitized:
@@ -74,13 +47,11 @@ def validate_prompt(text: str) -> Tuple[bool, str]:
         if forbidden in normalized:
             return False, f"forbidden_keyword:{forbidden}"
 
-    for required in REQUIRED_KEYWORDS:
-        if required not in normalized:
-            return False, f"missing_required:{required}"
+    warning: str = ""
+    length = len(sanitized)
+    if length < _SHORT_HINT_THRESHOLD:
+        warning = "prompt_short"
+    elif length > _LONG_HINT_THRESHOLD:
+        warning = "prompt_long"
 
-    if len(sanitized) < MIN_LENGTH:
-        return False, "prompt_too_short"
-    if len(sanitized) > MAX_LENGTH:
-        return False, "prompt_too_long"
-
-    return True, ""
+    return True, warning

--- a/app/services/prompt_templates.py
+++ b/app/services/prompt_templates.py
@@ -6,7 +6,7 @@ import random
 from typing import Iterable, Sequence
 
 ASSISTANT_SYSTEM = """
-You are a fashion prompt generator specialized in SFW women’s leatherwear. Produce exactly one polished text-to-image prompt per request. Describe both the clothing and the model in a neutral, tasteful way, covering materials, construction, silhouette, details, and the model’s attitude, pose, hair, and makeup. Keep the framing vertical portrait with the full outfit visible; suggest a 1024×1536 target size when relevant. Avoid brand names and copyrighted characters. Stay SFW with no nudity and no minors. Prefer concrete, material-centric vocabulary, such as leather types, finishes, stitching, hardware, closures, fit, and drape. Lighting and camera hints like soft daylight, an 85 mm lens look, or shallow depth of field are welcome. Output only the final prompt text with no preamble or markdown.
+You are a fashion prompt generator specialized in tasteful, SFW women’s leatherwear. Provide exactly one vivid text-to-image prompt for each request. Describe the outfit, the model, and the scene with an editorial tone that highlights leather materials, textures, construction, and styling details. Mention pose, lighting, and camera mood without dictating rigid settings. Avoid brand names and copyrighted characters. Keep every depiction mature and safe-for-work. Respond with a single paragraph of plain text and no additional framing.
 """.strip()
 
 SILHOUETTES: Sequence[str] = (
@@ -212,8 +212,8 @@ def build_randomized_user_prompt() -> str:
         mood = "modern and refined"
 
     prompt_parts = [
-        "Generate exactly one SFW text-to-image prompt in English for a women's leather outfit.",
-        f"Silhouette focus: {silhouette}.",
+        "Craft a single SFW text-to-image prompt in English for a women's leather fashion image.",
+        f"Silhouette inspiration: {silhouette}.",
         f"Primary garments: {', '.join(garments)}.",
         f"Leather material emphasis: {leather} in {color}.",
         f"Detailing cues: {', '.join(detailing)}.",
@@ -223,17 +223,11 @@ def build_randomized_user_prompt() -> str:
         f"Pose direction: {pose}.",
         f"Scene inspiration: {scene}.",
         f"Lighting direction: {lighting}.",
-        f"Camera and framing: {', '.join(camera)}.",
+        f"Camera feel: {', '.join(camera)}.",
         f"Overall mood: {mood}.",
         layering_note,
-        (
-            "Ensure the final prompt highlights leather as the central material, keeps everything SFW, and avoids brand names or copyrighted references."
-        ),
-        (
-            "State clearly that the composition uses vertical portrait framing with the full outfit visible and evokes a 1024x1536 aspect ratio feel."
-        ),
-        "Include vivid yet concise sensory cues about texture, stitching, and movement without exceeding roughly 150 words.",
-        "Output only the final polished prompt text with no lists, headings, or quotation marks.",
+        "Keep the description mature, tasteful, and clearly centered on leather craftsmanship without mentioning brands.",
+        "Blend outfit, model, setting, and atmosphere into one flowing paragraph with vivid yet concise sensory detail.",
     ]
 
     filtered_parts = [part for part in prompt_parts if part]

--- a/app/smoke_test.py
+++ b/app/smoke_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import time
 from typing import Sequence
 
 from app import logging_conf
@@ -52,6 +53,8 @@ def main() -> None:
 
     try:
         prompt = assistant_service.generate_prompt_text()
+        LOGGER.info("sleeping 30s before image generation")
+        time.sleep(30)
         aspect_key = args.aspect.upper()
         images = gemini_service.generate_images(prompt, n=args.n, aspect=aspect_key, fmt="png")
 


### PR DESCRIPTION
## Summary
- simplify the assistant system prompt and soft guard to only enforce high-level SFW checks while keeping randomized context
- adjust assistant prompt generation to treat guard feedback as warnings and streamline logging
- rely on Gemini defaults for image generation and insert the required 30 second pause before calling the model in the smoke test

## Testing
- python -m compileall app/services
- python -m compileall app/services/gemini_service.py

------
https://chatgpt.com/codex/tasks/task_e_68d905724e78832e94b2af32b8bda72d