### PR TITLE
Send Telegram prompts without pre-splitting

### DIFF
--- a/app/smoke_test.py
+++ b/app/smoke_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import logging
 import time
 from typing import Sequence
@@ -53,6 +54,11 @@ def main() -> None:
 
     try:
         prompt = assistant_service.generate_prompt_text()
+        LOGGER.info(
+            "generated prompt metadata: length=%d hash=%s",
+            len(prompt),
+            hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:8],
+        )
         LOGGER.info("sleeping 30s before image generation")
         time.sleep(30)
         aspect_key = args.aspect.upper()


### PR DESCRIPTION
## Summary
- send the prompt in a single Telegram message after the album and fall back to emergency splitting only when Telegram rejects it
- remove the pre-chunking helper and log prompt length/hash metadata instead of raw text
- record prompt metadata during the smoke test run for visibility

## Testing
- python -m compileall app/services/telegram_service.py app/smoke_test.py

------
https://chatgpt.com/codex/tasks/task_e_68d90ab6d688832e9cf0d55577ae2467